### PR TITLE
Update chan_iax2.c

### DIFF
--- a/asterisk/channels/chan_iax2.c
+++ b/asterisk/channels/chan_iax2.c
@@ -110,9 +110,12 @@ ASTERISK_FILE_VERSION(__FILE__, "$Revision$")
 #include "jitterbuf.h"
 
 /* WB6NIL backport stuff */
+/* N2MH patches - 2022-07-21 */
+//#define	DAHDI_FILE_TIMER "/dev/zap/timer"   <-- old line
+//#define	DAHDI_FILE_PSEUDO "/dev/zap/pseudo" <-- old line
+#define	DAHDI_FILE_TIMER "/dev/dahdi/timer"
+#define	DAHDI_FILE_PSEUDO "/dev/dahdi/pseudo"
 
-#define	DAHDI_FILE_TIMER "/dev/zap/timer"
-#define	DAHDI_FILE_PSEUDO "/dev/zap/pseudo"
 #define	AST_FORMAT_AUDIO_UNDEFINED 0
 #define	BAD_RADIO_HACK
 #define	ast_free_ptr ast_free


### PR DESCRIPTION
I run ASL as a pbx as well as an ASL node. Every time I would reload the pbx configs, an error would appear to the effect that IAX trunking is not available without a timing source. I thought this was strange since every indication showed that dahdi/pseudo was in fact running. Thus it appeared that IAX was not pulling in the timing from the kernel. Looking through chan_iax.c, I found two bad file descriptors, probably left over from the zaptel days that were trying to pull in zaptel timing (the "old lines" above). I corrected them to show /dev/dahdi/... After the change, no more errors about an inability to do trunking. Note, part of this fix was determining that /dev/zap/... did not exist and that /dev/dahdi/... did exist.

Changes start on line 112. Two original lines commented out. Two new lines inserted.

This is the first time I am using Github, so please excuse and errors in procedure.